### PR TITLE
Add demo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Despite its simple rule set, the ant's path eventually develops a recurring "hig
 
 The demo runs a sequence of MCP Tool calls that create a repository in your personal account.
 
-1. Install [GitHub MCP Server](https://github.com/github/github-mcp-server?tab=readme-ov-file#installation).
+1. Install [GitHub MCP Server](https://github.com/github/github-mcp-server#installation).
 2. Start the server (requires Docker).
 3. Open Copilot Chat in Agent mode (Sonnet models give the best results).
 4. Run: `/createRepo`
-5. Run: 
+5. Run: `Add an issue to split HTML, CSS and JS in separate files and assign it to me`
 ```
-Add an issue to split HTML, CSS and JS in separte files and assign it to me
+Add an issue to split HTML, CSS and JS in separate files and assign it to me
 ```
 6. Run:
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ Langton's Ant is a two-dimensional Turing machine with a very simple set of rule
 
 Despite its simple rule set, the ant's path eventually develops a recurring "highway" pattern of repeating movements.
 
+## Running the demo
+
+The demo runs a sequence of MCP Tool calls that create a repository in your personal account.
+
+1. Install [GitHub MCP Server](https://github.com/github/github-mcp-server?tab=readme-ov-file#installation).
+2. Start the server (requires Docker).
+3. Open Copilot Chat in Agent mode (Sonnet models give the best results).
+4. Run: `/createRepo`
+5. Run: 
+```
+Add an issue to split HTML, CSS and JS in separte files and assign it to me
+```
+6. Run:
+```
+Fix issue #1 on a separate branch and open a PR
+```
+7. Check the repository created, the issue, the pull request and the Pages site.
+
 ## Acknowledgments
 
 - Chris Langton for creating the original cellular automaton


### PR DESCRIPTION
This pull request adds a new section to the `README.md` file that provides instructions for running a demo related to Langton's Ant. The demo involves using GitHub MCP Server and Copilot Chat in Agent mode to automate repository creation, issue management, and pull request workflows.

### Added demo instructions:

* **New section in `README.md`:** A "Running the demo" section has been added, detailing steps to install and start GitHub MCP Server, use Copilot Chat in Agent mode, and execute specific commands to create a repository, manage issues, and open pull requests.